### PR TITLE
feat: added padding between each Timeline component and added custom Tailwind CSS variant to enable adding css to non last child in a container

### DIFF
--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -4,21 +4,22 @@ import TimelineItem from "./TimelineItem";
 import SectionTitle from "./SectionTitle";
 
 function Timeline() {
-  return (
-    <div className="flex flex-col md:flex-row justify-start my-2">
-      <div className="w-full md:w-10/12">
-        <SectionTitle title={"Timeline"} />
-        {timeline.map((item) => (
-          <TimelineItem
-            year={item.year}
-            title={item.title}
-            duration={item.duration}
-            details={item.details}
-          />
-        ))}
-      </div>
-    </div>
-  );
+    return (
+        <div className='flex flex-col md:flex-row justify-start my-2'>
+            <div className='w-full md:w-10/12'>
+                <SectionTitle title={"Timeline"} />
+                {timeline.map((item, i) => (
+                    <TimelineItem
+                        key={i}
+                        year={item.year}
+                        title={item.title}
+                        duration={item.duration}
+                        details={item.details}
+                    />
+                ))}
+            </div>
+        </div>
+    );
 }
 
 export default Timeline;

--- a/src/components/TimelineItem.jsx
+++ b/src/components/TimelineItem.jsx
@@ -1,39 +1,39 @@
 import React from "react";
 
 function Timeline({ year, title, duration, details }) {
-  return (
-    <ol className="flex flex-col md:flex-row relative border-l border-stone-200">
-      <li className="ml-4">
-        <div className="absolute w-3 h-3 bg-stone-800 rounded-full mt-1.5 -left-1.5 border border-white" />
-        <div className="group p-4 transition duration-300 border border-transparent hover:border-slate-500 rounded-lg">
-          <p className="flex flex-col md:flex-row items-start gap-4 text-xs md:text-sm">
-            <div className="flex flex-col items-start">
-              <h3 className="text-lg font-semibold text-stone-900 dark:text-white py-1">
-                {title}
-              </h3>
-              <div className="flex gap-4 items-start">
-                <span className="inline-block px-2 py-1 font-semibold text-white bg-stone-900 rounded-md">
-                  {year}
-                </span>
-                <div className="my-1 text-sm font-normal leading-none text-stone-400 dark:text-stone-100">
-                  {duration}
-                </div>
-              </div>
-            </div>
-          </p>
+    return (
+        <ol className='flex flex-col md:flex-row relative border-l border-stone-200 not-last-child:pb-4'>
+            <li className='ml-4'>
+                <div className='absolute w-3 h-3 bg-stone-800 rounded-full mt-1.5 -left-1.5 border border-white' />
+                <div className='group p-4 transition duration-300 border border-transparent hover:border-slate-500 rounded-lg'>
+                    <p className='flex flex-col md:flex-row items-start gap-4 text-xs md:text-sm'>
+                        <div className='flex flex-col items-start'>
+                            <h3 className='text-lg font-semibold text-stone-900 dark:text-white py-1'>
+                                {title}
+                            </h3>
+                            <div className='flex gap-4 items-start'>
+                                <span className='inline-block px-2 py-1 font-semibold text-white bg-stone-900 rounded-md'>
+                                    {year}
+                                </span>
+                                <div className='my-1 text-sm font-normal leading-none text-stone-400 dark:text-stone-100'>
+                                    {duration}
+                                </div>
+                            </div>
+                        </div>
+                    </p>
 
-          <p className="my-2 text-base font-normal text-stone-500 dark:text-stone-300 font-SourceCodePro pb-6">
-            {details.split("\n").map((sentence, index) => (
-              <React.Fragment key={index}>
-                {sentence}
-                <br />
-              </React.Fragment>
-            ))}
-          </p>
-        </div>
-      </li>
-    </ol>
-  );
+                    <p className='my-2 text-base font-normal text-stone-500 dark:text-stone-300 font-SourceCodePro pb-6'>
+                        {details.split("\n").map((sentence, index) => (
+                            <React.Fragment key={index}>
+                                {sentence}
+                                <br />
+                            </React.Fragment>
+                        ))}
+                    </p>
+                </div>
+            </li>
+        </ol>
+    );
 }
 
 export default Timeline;

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,22 +1,33 @@
 /**  @type {import('tailwindcss').Config} */
 
 module.exports = {
-  content: ["./index.html", "./src/**/*.{jsx,js}"],
-  darkMode: "class",
-  theme: {
-    extend: {
-      fontFamily: {
-        Oswald: ["Oswald", "serif"],
-        SourceCodePro: ["Source Code Pro", "monospace", "sans-serif"],
-      },
-      backgroundColor: {
-        "green-300": "#556B2F",
-        "swift-300": "#FA7343",
-        "react-300": "#68DBFB",
-        "onyx-300": "#353839",
-        "sage-300": "#92AFAD",
-      },
+    content: ["./index.html", "./src/**/*.{jsx,js}"],
+    darkMode: "class",
+    theme: {
+        extend: {
+            fontFamily: {
+                Oswald: ["Oswald", "serif"],
+                SourceCodePro: ["Source Code Pro", "monospace", "sans-serif"],
+            },
+            backgroundColor: {
+                "green-300": "#556B2F",
+                "swift-300": "#FA7343",
+                "react-300": "#68DBFB",
+                "onyx-300": "#353839",
+                "sage-300": "#92AFAD",
+            },
+        },
     },
-  },
-  plugins: [],
+    //a custom variant to check if the element is the last child within its parent container
+    plugins: [
+        function ({ addVariant, e }) {
+            addVariant("not-last-child", ({ modifySelectors, separator }) => {
+                modifySelectors(({ className }) => {
+                    return `.${e(
+                        `not-last-child${separator}${className}`
+                    )}:not(:last-child)`;
+                });
+            });
+        },
+    ],
 };


### PR DESCRIPTION
Created a custom variant "not-last-child" in the Tailwind CSS configuration to conditionally apply styles to elements that are not the last child within their parent containers. This variant allows for more precise styling, especially in scenarios where you want to remove or adjust styles for the last element in a list or group of elements.

Usage example: <div class="pb-4 not-last-child:pb-0">...</div>
<img width="946" alt="Screenshot 2024-01-20 014719" src="https://github.com/hubertle43100/minimal-portfolio/assets/30834202/df7d61a7-2a57-450c-ac9c-a3a3ee8ad965">
<img width="946" alt="Screenshot 2024-01-20 015516" src="https://github.com/hubertle43100/minimal-portfolio/assets/30834202/e15e8efb-4d71-4364-9934-b008ab0d6dcb">
<img width="952" alt="Screenshot 2024-01-20 015533" src="https://github.com/hubertle43100/minimal-portfolio/assets/30834202/3dcc58e4-4c84-4de9-8bde-4e877700cd3d">


this fixes Make space between timeline hover #9